### PR TITLE
0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trve_bevy_image"
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2021"
 bevy = { version = "0.17", default-features = false, features = [
     "bevy_asset",
     "bevy_log",
-    "bevy_render",
+    "bevy_image",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trve_bevy_image"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.16", default-features = false, features = [
+bevy = { version = "0.17", default-features = false, features = [
     "bevy_asset",
     "bevy_log",
     "bevy_render",

--- a/README.md
+++ b/README.md
@@ -9,17 +9,7 @@ This plugin is meant to be a convenience tool to load all image assets for your 
 To use it, add it to your Cargo.toml file like this:
 
 ```toml
-trve_bevy_image = { git = "https://github.com/mnmaita/trve_bevy_image" }
-```
-
-Remember you can also target tags, commits and branches with this method:
-
-```toml
-trve_bevy_image = { git = "https://github.com/mnmaita/trve_bevy_image", tag = "v0.6.0" }
-```
-
-```toml
-trve_bevy_image = { git = "https://github.com/mnmaita/trve_bevy_image", branch = "test" }
+trve_bevy_image = { git = "https://github.com/mnmaita/trve_bevy_image", tag = "v0.7.0" }
 ```
 
 ```toml
@@ -80,6 +70,7 @@ If you insert this Resource the plugin will **only** load the assets provided in
 
 | trve_bevy_image | bevy |
 | --------------- | ---- |
+| 0.7             | 0.17 |
 | 0.6             | 0.16 |
 | 0.5             | 0.15 |
 | 0.3, 0.4        | 0.14 |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,3 @@
 mod plugin;
 
-pub use plugin::{image_assets_loaded, ImageAssetFolder, ImageAssetList, TrveImagePlugin};
+pub use plugin::{ImageAssetFolder, ImageAssetList, TrveImagePlugin, image_assets_loaded};

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,14 @@
 use bevy::{
-    asset::{AssetPath, LoadedFolder, RecursiveDependencyLoadState},
-    prelude::*,
+    app::{App, Plugin, Startup, Update},
+    asset::{AssetPath, AssetServer, Handle, LoadedFolder, RecursiveDependencyLoadState},
+    ecs::{
+        resource::Resource,
+        schedule::{common_conditions::not, IntoScheduleConfigs},
+        system::{Commands, Res, ResMut},
+    },
+    image::Image,
+    log::info,
+    prelude::{Deref, DerefMut},
 };
 
 pub struct TrveImagePlugin;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -3,7 +3,7 @@ use bevy::{
     asset::{AssetPath, AssetServer, Handle, LoadedFolder, RecursiveDependencyLoadState},
     ecs::{
         resource::Resource,
-        schedule::{common_conditions::not, IntoScheduleConfigs},
+        schedule::{IntoScheduleConfigs, common_conditions::not},
         system::{Commands, Res, ResMut},
     },
     image::Image,
@@ -68,6 +68,10 @@ impl std::fmt::Display for ImageAssetFolder<'_> {
 /// Example:
 ///
 /// ```
+/// use trve_bevy_image::ImageAssetList;
+///
+/// let mut app = bevy::app::App::new();
+///
 /// app.insert_resource(ImageAssetList::new(
 ///     [
 ///         "image1.png",


### PR DESCRIPTION
* Updated Bevy to 0.17.
* Simplified usage section in README.
* Replaced `bevy_render` feature with the more appropriate `bevy_image`.
* Updated to rust 2024 edition.
* Fixed rustdoc issues.